### PR TITLE
Error abstraction

### DIFF
--- a/pygate_grpc/client.py
+++ b/pygate_grpc/client.py
@@ -1,5 +1,6 @@
-import proto.ffs_rpc_pb2 as ffs_rpc_pb2
+from proto import ffs_rpc_pb2
 from pygate_grpc import health, faults, deals, ffs
+
 
 class PowerGateClient(object):
     def __init__(self, host_name):
@@ -7,7 +8,3 @@ class PowerGateClient(object):
         self.faults = faults.FaultsClient(host_name)
         self.deals = deals.DealsClient(host_name)
         self.ffs = ffs.FfsClient(host_name)
-
-
-if __name__ == "__main__":
-    pass

--- a/pygate_grpc/deals.py
+++ b/pygate_grpc/deals.py
@@ -1,10 +1,11 @@
 import grpc
 
-import proto.deals_rpc_pb2 as deals_rpc_pb2
-import proto.deals_rpc_pb2_grpc as deals_rpc_pb2_grpc
+from proto import deals_rpc_pb2
+from proto import deals_rpc_pb2_grpc
+from pygate_grpc.errors import ErrorHandlerMeta
 
 
-class DealsClient(object):
+class DealsClient(object, metaclass=ErrorHandlerMeta):
     ## THIS USED AN OUTDATED PROTO SPECIFICATION IT NEEDS RE DEVELOPMENT
     def __init__(self, host_name):
         channel = grpc.insecure_channel(host_name)

--- a/pygate_grpc/errors.py
+++ b/pygate_grpc/errors.py
@@ -1,0 +1,37 @@
+import grpc
+import logging
+
+from pygate_grpc.exceptions import GRPCNotAvailableException
+
+logger = logging.getLogger(__name__)
+
+
+def error_handler(func):
+    """A decorator to handle errors"""
+
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except grpc._channel._InactiveRpcError as e:
+            err_to_raise = e
+            if err_to_raise.code() == grpc.StatusCode.UNAVAILABLE:
+                err_to_raise = GRPCNotAvailableException(e)
+        raise err_to_raise
+
+    return wrapper
+
+
+class ErrorHandlerMeta(type):
+    """
+    A metaclass to embed a global error handler for class methods.
+
+    Mainly used to abstract tout GRPC exceptions.
+    """
+
+    def __new__(cls, classname, bases, classdict):
+
+        for attr, item in classdict.items():
+            if callable(item):
+                classdict[attr] = error_handler(item)  # replace method by wrapper
+
+        return type.__new__(cls, classname, bases, classdict)

--- a/pygate_grpc/exceptions.py
+++ b/pygate_grpc/exceptions.py
@@ -1,0 +1,4 @@
+class GRPCNotAvailableException(Exception):
+    def __init__(self, err, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.original_err = err

--- a/pygate_grpc/faults.py
+++ b/pygate_grpc/faults.py
@@ -1,10 +1,11 @@
 import grpc
 
-import proto.faults_rpc_pb2 as faults_rpc_pb2
-import proto.faults_rpc_pb2_grpc as faults_rpc_pb2_grpc
+from proto import faults_rpc_pb2
+from proto import faults_rpc_pb2_grpc
+from pygate_grpc.errors import ErrorHandlerMeta
 
 
-class FaultsClient(object):
+class FaultsClient(object, metaclass=ErrorHandlerMeta):
     def __init__(self, host_name):
         channel = grpc.insecure_channel(host_name)
         self.client = faults_rpc_pb2_grpc.RPCServiceStub(channel)

--- a/pygate_grpc/ffs.py
+++ b/pygate_grpc/ffs.py
@@ -1,12 +1,14 @@
 import grpc
 
-import proto.ffs_rpc_pb2 as ffs_rpc_pb2
-import proto.ffs_rpc_pb2_grpc as ffs_rpc_pb2_grpc
+from proto import ffs_rpc_pb2
+from proto import ffs_rpc_pb2_grpc
+from pygate_grpc.errors import ErrorHandlerMeta
 
-TOKEN_KEY = 'x-ffs-token'
+TOKEN_KEY = "x-ffs-token"
 CHUNK_SIZE = 1024 * 1024  # 1MB
 
-class FfsClient(object):
+
+class FfsClient(object, metaclass=ErrorHandlerMeta):
     def __init__(self, host_name):
         self.host_name = host_name
         channel = grpc.insecure_channel(host_name)
@@ -62,7 +64,7 @@ class FfsClient(object):
         return self.client.PushConfig(req, metadata=self._get_meta_data(token))
 
     def get_file_bytes(self, filename):
-        with open(filename, 'rb') as f:
+        with open(filename, "rb") as f:
             while True:
                 piece = f.read(CHUNK_SIZE)
                 if len(piece) == 0:
@@ -76,5 +78,3 @@ class FfsClient(object):
     def chunks_to_bytes(self, chunks):
         for c in chunks:
             yield c.chunk
-
-

--- a/pygate_grpc/health.py
+++ b/pygate_grpc/health.py
@@ -1,12 +1,14 @@
 import grpc
 import logging
-import proto.health_rpc_pb2 as health_rpc_pb2
-import proto.health_rpc_pb2_grpc as health_rpc_pb2_grpc
+
+from proto import health_rpc_pb2
+from proto import health_rpc_pb2_grpc
+from pygate_grpc.errors import ErrorHandlerMeta
 
 logger = logging.getLogger(__name__)
 
 
-class HealthClient(object):
+class HealthClient(object, metaclass=ErrorHandlerMeta):
     def __init__(self, host_name):
         channel = grpc.insecure_channel(host_name)
         self.client = health_rpc_pb2_grpc.RPCServiceStub(channel)

--- a/tests/integration/test_ffs.py
+++ b/tests/integration/test_ffs.py
@@ -6,6 +6,7 @@ from pygate_grpc.client import PowerGateClient
 
 logger = logging.getLogger(__name__)
 
+
 @pytest.fixture(scope="module")
 def ffs_instance(pygate_client: PowerGateClient):
     return pygate_client.ffs.create()
@@ -31,6 +32,7 @@ def test_grpc_ffs_add_to_hot(pygate_client: PowerGateClient, ffs_instance):
 
     assert res is not None
     assert res.cid is not None
+
 
 def test_chunks():
     for _ in range(1):


### PR DESCRIPTION
Adds a metaclass which embeds a global error handler in each of the powergate endpoint clients.

This rationale behind this logic is to completely abstract the errors from the package such that the user does not have to deal with low level grpc errors.