### PR TITLE
Fix multivalue display from FFS config

### DIFF
--- a/cidconfig.json
+++ b/cidconfig.json
@@ -11,8 +11,8 @@
     "filecoin": {
       "repFactor": 1,
       "dealMinDuration": 1000,
-      "excludedMiners": null,
-      "trustedMiners": ["t01000"],
+      "excludedMiners": ["t01101"],
+      "trustedMiners": ["t01000", "t02000"],
       "countryCodes": ["ca", "nl"],
       "renew": {
         "enabled": true,

--- a/examples/ffs_config.py
+++ b/examples/ffs_config.py
@@ -1,5 +1,6 @@
 import json
 from pygate_grpc.client import PowerGateClient
+from google.protobuf.json_format import MessageToDict
 
 client = PowerGateClient("127.0.0.1:5002")
 
@@ -18,5 +19,6 @@ with open("cidconfig.json", "r") as f:
 client.ffs.set_default_config(config, tk)
 
 defaultConfig = client.ffs.default_config(tk)
+
 print("Updated default config:")
-print(defaultConfig)
+print(json.dumps(MessageToDict(defaultConfig), indent=2))


### PR DESCRIPTION
This commit fixes the error where multi-value arrays where getting split into key/value pairs. The solution was to convert using google.protobuf.json_format MessageToDict(). However, this is an interim fix. The permanent solution is to push MessageToDict to the grpc client and have it return a dictionary rather than a protobuf message. I tried to implement that but got stuck.